### PR TITLE
OS X port of OpenRW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ option(ENABLE_PROFILING "Enable detailed profiling metrics")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	add_definitions(-DRW_LINUX=1)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	add_definitions(-DRW_OSX=1)
 else ()
 	message(FATAL_ERROR "Unknown platform \"${CMAKE_SYSTEM_NAME}\". please update CMakeLists.txt.")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ else ()
 	message(FATAL_ERROR "Unknown platform \"${CMAKE_SYSTEM_NAME}\". please update CMakeLists.txt.")
 endif ()
 
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-array-member-paren-init")
+endif()
+
 # Make GLM use radians
 add_definitions(-DGLM_FORCE_RADIANS)
 

--- a/rwengine/include/data/CutsceneData.hpp
+++ b/rwengine/include/data/CutsceneData.hpp
@@ -4,6 +4,7 @@
 #include <glm/glm.hpp>
 #include <map>
 #include <vector>
+#include <string>
 
 /**
  * @brief Stores data from .CUT files

--- a/rwengine/include/script/ScriptMachine.hpp
+++ b/rwengine/include/script/ScriptMachine.hpp
@@ -10,6 +10,7 @@
 #include <stack>
 #include <list>
 #include <set>
+#include <array>
 
 #define SCM_NEGATE_CONDITIONAL_MASK 0x8000
 #define SCM_CONDITIONAL_MASK_PASSED 0xFF

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -30,7 +30,7 @@
  */
 std::string findPathRealCase(const std::string& base, const std::string& path) 
 {
-#ifdef __unix__
+#ifndef _WIN32
 	size_t endslash = path.find("/");
 	bool isDirectory = true;
 	if(endslash == path.npos) {


### PR DESCRIPTION
Hi,
beside some small compilation errors, this also fixes `findPathRealCase` in `rwengine/src/engine/GameData.cpp` on OS X.

On a side note, it does not correctly render yet. (first of, the shaders do not even compile because of core/compatibility profile issues on OS X)

(This was tested on 10.11.5)