### PR TITLE
[CMake] Use find_package config mode for GLM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ find_package(OpenGL REQUIRED)
 find_package(Bullet REQUIRED)
 find_package(SFML 2 COMPONENTS system window audio graphics network REQUIRED)
 find_package(MAD REQUIRED)
-find_package(GLM REQUIRED)
+find_package(glm REQUIRED CONFIG)
 
 include_directories("${GLM_INCLUDE_DIRS}")
 


### PR DESCRIPTION
GLM requires using the new config mode as it only ships a
glmConfig.cmake.

more info:
http://stackoverflow.com/q/34634850/4453524
https://cmake.org/cmake/help/latest/command/find_package.html

fixes https://github.com/danhedron/openrw/issues/41