### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 script:
     - mkdir build
     - cd build
-    - cmake .. -DBUILD_TESTS=1 && make
+    - cmake .. -DBUILD_TESTS=1 -DTESTS_NODATA=1 && make
     - tests/run_tests
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+dist: trusty
+language: cpp
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -y libbullet-dev libsfml-dev libmad0-dev libglm-dev libsndfile-dev libopenal-dev libboost-test-dev
+git:
+    depth: 3
+script:
+    - mkdir build
+    - cd build
+    - cmake .. -DBUILD_TESTS=1 && make
+    - tests/run_tests
+notifications:
+    email: false
+#    irc:
+#        channels:
+#            - chat.freenode.net#openrw
+#        template:
+#            - "%{repository}/%{branch} (%{commit} - %{author}): %{build_url}: %{message}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(BUILD_SCRIPT_TOOL "Build script decompiler tool")
 # Compile-time Options & Features
 option(ENABLE_SCRIPT_DEBUG "Enable verbose script execution")
 option(ENABLE_PROFILING "Enable detailed profiling metrics")
+option(TESTS_NODATA "Build tests for no-data testing")
 
 #
 # Build configuration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,12 @@
 #    Unit Tests
 ##############################################################################
 
+if(${TESTS_NODATA})
+	add_definitions(-DRW_TEST_WITH_DATA=0)
+else()
+	add_definitions(-DRW_TEST_WITH_DATA=1)
+endif()
+
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 set(TEST_SOURCES

--- a/tests/test_FileIndex.cpp
+++ b/tests/test_FileIndex.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(FileIndexTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_index)
 {
 	FileIndex index;
@@ -49,5 +50,6 @@ BOOST_AUTO_TEST_CASE(test_file_archive)
 	auto handle = index.openFile("landstal.dff");
 	BOOST_CHECK( handle != nullptr );
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_GameData.cpp
+++ b/tests/test_GameData.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(GameDataTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_object_data)
 {
 	GameData gd(&Global::get().log, &Global::get().work, Global::getGamePath());
@@ -27,5 +28,6 @@ BOOST_AUTO_TEST_CASE(test_object_data)
 		BOOST_CHECK_EQUAL( def->flags, 0 );
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_GameWorld.cpp
+++ b/tests/test_GameWorld.cpp
@@ -6,6 +6,7 @@
 
 BOOST_AUTO_TEST_SUITE(GameWorldTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_gameobject_id)
 {
 	GameWorld gw(&Global::get().log, &Global::get().work, Global::get().d);
@@ -15,5 +16,6 @@ BOOST_AUTO_TEST_CASE(test_gameobject_id)
 
 	BOOST_CHECK_NE( object1->getGameObjectID(), object2->getGameObjectID() );
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -7,6 +7,7 @@
 
 BOOST_AUTO_TEST_SUITE(AnimationTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_matrix)
 {
 	{
@@ -47,6 +48,7 @@ BOOST_AUTO_TEST_CASE(test_matrix)
 		BOOST_CHECK( skeleton.getData(0).b.translation == glm::vec3(0.f, 0.f, 0.f) );
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_archive.cpp
+++ b/tests/test_archive.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(ArchiveTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_open_archive)
 {
 	LoaderIMG archive;
@@ -28,5 +29,6 @@ BOOST_AUTO_TEST_CASE(test_open_archive)
 	BOOST_CHECK_EQUAL( f2.offset, f.offset );
 	BOOST_CHECK_EQUAL( f2.size, f.size );
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_buoyancy.cpp
+++ b/tests/test_buoyancy.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(BuoyancyTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy)
 {
 	glm::vec2 tpos(-WATER_WORLD_SIZE/2.f + 10.f);
@@ -56,6 +57,7 @@ BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy)
 		Global::get().e->destroyObject(vehicle);
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -7,6 +7,7 @@
 
 BOOST_AUTO_TEST_SUITE(CharacterTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_create)
 {
 	{
@@ -143,6 +144,7 @@ BOOST_AUTO_TEST_CASE(test_death)
 		delete controller;
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_chase.cpp
+++ b/tests/test_chase.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(ChaseTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_load_keyframes)
 {
 	std::vector<ChaseKeyframe> keyframes;
@@ -11,5 +12,6 @@ BOOST_AUTO_TEST_CASE(test_load_keyframes)
 	BOOST_REQUIRE(keyframes.size() == 5400);
 	BOOST_CHECK_CLOSE(keyframes[0].position.x, 273.5422, 0.1);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_cutscene.cpp
+++ b/tests/test_cutscene.cpp
@@ -5,6 +5,7 @@
 
 BOOST_AUTO_TEST_SUITE(CutsceneTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_load)
 {
 	{
@@ -28,5 +29,6 @@ BOOST_AUTO_TEST_CASE(test_load)
 		BOOST_CHECK( tracks.duration == 64.8f );
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -8,6 +8,7 @@
 
 BOOST_AUTO_TEST_SUITE(DataTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_weapon_dat)
 {
 	GenericDATLoader l;
@@ -85,6 +86,7 @@ BOOST_AUTO_TEST_CASE(test_handling_data_loader)
 	BOOST_CHECK_EQUAL( handling.driveType, VehicleHandlingInfo::All );
 	BOOST_CHECK_EQUAL( handling.engineType, VehicleHandlingInfo::Petrol );
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_globals.hpp
+++ b/tests/test_globals.hpp
@@ -8,7 +8,9 @@
 #include <core/Logger.hpp>
 #include <glm/gtx/string_cast.hpp>
 
+#if RW_TEST_WITH_DATA
 #define ENV_GAME_PATH_NAME ("OPENRW_GAME_PATH")
+#endif
 
 std::ostream& operator<<( std::ostream& stream, glm::vec3 const& v );
 
@@ -49,14 +51,17 @@ class Global
 {
 public:
 	sf::Window wnd;
+#if RW_TEST_WITH_DATA
 	GameData* d;
 	GameWorld* e;
 	GameState* s;
 	Logger log;
 	WorkContext work;
-	
+#endif
+
 	Global() {
 		wnd.create(sf::VideoMode(640, 360), "Testing");
+#if RW_TEST_WITH_DATA
 		d = new GameData(&log, &work, getGamePath());
 
 		d->loadIMG("/models/gta3");
@@ -78,19 +83,24 @@ public:
 		while( ! e->_work->isEmpty() ) {
 			std::this_thread::yield();
 		}
+#endif
 	}
 
 	~Global() {
 		wnd.close();
+#if RW_TEST_WITH_DATA
 		delete e;
+#endif
 	}
 
+#if RW_TEST_WITH_DATA
 	static std::string getGamePath()
 	{
 		// TODO: Is this "the way to do it" on windows.
 		auto v = getenv(ENV_GAME_PATH_NAME);
 		return v ? v : "";
 	}
+#endif
 	
 	static Global& get()
 	{

--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -4,6 +4,8 @@
 #include "test_globals.hpp"
 
 BOOST_AUTO_TEST_SUITE(ItemTests)
+
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_character_inventory)
 {
 	{
@@ -32,6 +34,7 @@ BOOST_AUTO_TEST_CASE(test_character_inventory)
 		Global::get().e->destroyObject(character);
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_lifetime.cpp
+++ b/tests/test_lifetime.cpp
@@ -5,6 +5,7 @@
 
 BOOST_AUTO_TEST_SUITE(LifetimeTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_cleanup)
 {
 	GameObject* f = Global::get().e->createInstance(1337, glm::vec3(0.f, 0.f, 1000.f));
@@ -25,5 +26,6 @@ BOOST_AUTO_TEST_CASE(test_cleanup)
 		BOOST_CHECK( search != objects.end() );
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_loaderdff.cpp
+++ b/tests/test_loaderdff.cpp
@@ -6,6 +6,7 @@
 
 BOOST_AUTO_TEST_SUITE(LoaderDFFTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_load_dff)
 {
 	{
@@ -64,5 +65,6 @@ BOOST_AUTO_TEST_CASE(test_loader_job)
 	}
 
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_object_data.cpp
+++ b/tests/test_object_data.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(ObjectDataTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_object_data)
 {
 	{
@@ -54,5 +55,6 @@ BOOST_AUTO_TEST_CASE(test_gamedata_data)
 {
 	
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_pickup.cpp
+++ b/tests/test_pickup.cpp
@@ -23,6 +23,7 @@ public:
 
 BOOST_AUTO_TEST_SUITE(PickupTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_pickup_interaction)
 {
 	{
@@ -90,6 +91,7 @@ BOOST_AUTO_TEST_CASE(test_item_pickup)
 		Global::get().e->destroyObject(character);
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_rwbstream.cpp
+++ b/tests/test_rwbstream.cpp
@@ -4,6 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE(RWBStreamTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(iterate_stream_test)
 {
 	{
@@ -27,5 +28,6 @@ BOOST_AUTO_TEST_CASE(iterate_stream_test)
 		BOOST_CHECK_EQUAL( *(std::uint32_t*)innerCursor, 0x10 );
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_text.cpp
+++ b/tests/test_text.cpp
@@ -6,6 +6,7 @@
 
 BOOST_AUTO_TEST_SUITE(TextTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(load_test)
 {
 	{
@@ -166,5 +167,6 @@ BOOST_AUTO_TEST_CASE(format_remove)
 
 	BOOST_CHECK_EQUAL(1, st.getText<ScreenTextType::Big>().size());
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_trafficdirector.cpp
+++ b/tests/test_trafficdirector.cpp
@@ -11,6 +11,7 @@ std::ostream &operator<<(std::ostream &os, const AIGraphNode* yt) { os << glm::t
 
 BOOST_AUTO_TEST_SUITE(TrafficDirectorTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_available_nodes)
 {
 	AIGraph graph;
@@ -214,5 +215,6 @@ BOOST_AUTO_TEST_CASE(test_create_traffic)
 	
 	//Global::get().e->destroyObject(created[0]);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -6,6 +6,7 @@
 
 BOOST_AUTO_TEST_SUITE(VehicleTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_create_vehicle)
 {
 	VehicleObject* vehicle = Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
@@ -128,6 +129,7 @@ BOOST_AUTO_TEST_CASE(test_open_part)
 	
 	Global::get().e->destroyObject(vehicle);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tests/test_weapon.cpp
+++ b/tests/test_weapon.cpp
@@ -6,6 +6,7 @@
 
 BOOST_AUTO_TEST_SUITE(WeaponTests)
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(TestWeaponScan)
 {
 	{
@@ -125,5 +126,6 @@ BOOST_AUTO_TEST_CASE(TestProjectile)
 		Global::get().e->destroyQueuedObjects();
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a travis ci configuration, and adds a macro to disable tests that rely on having the game data present. As many of these tests as possible should be changed to avoid that requirement, since it's not practical for doing CI like this.
