### PR TITLE
Anim groups

### DIFF
--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -29,6 +29,8 @@ set(RWENGINE_SOURCES
 	src/core/Logger.hpp
 	src/core/Profiler.cpp
 	src/core/Profiler.hpp
+	src/data/AnimGroup.cpp
+	src/data/AnimGroup.hpp
 	src/data/Chase.cpp
 	src/data/Chase.hpp
 	src/data/CollisionModel.hpp

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -202,14 +202,14 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
     auto entryPos = vehicle->getSeatEntryPositionWorld(seat);
     auto entryPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_open = character->animations.car_open_lhs;
-    auto anm_enter = character->animations.car_getin_lhs;
-    auto anm_pullout = character->animations.car_pullout_lhs;
+    auto anm_open = character->animations->car_open_lhs;
+    auto anm_enter = character->animations->car_getin_lhs;
+    auto anm_pullout = character->animations->car_pullout_lhs;
 
     if (entryPosLocal.x > 0.f) {
-        anm_open = character->animations.car_open_rhs;
-        anm_enter = character->animations.car_getin_rhs;
-        anm_pullout = character->animations.car_pullout_rhs;
+        anm_open = character->animations->car_open_rhs;
+        anm_enter = character->animations->car_getin_rhs;
+        anm_pullout = character->animations->car_pullout_rhs;
     }
 
     // If there's someone in this seat already, we may have to ask them to
@@ -298,8 +298,8 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     RW_UNUSED(controller);
 
     if (jacked) {
-        auto anm_jacked_lhs = character->animations.car_jacked_lhs;
-        auto anm_jacked_rhs = character->animations.car_jacked_lhs;
+        auto anm_jacked_lhs = character->animations->car_jacked_lhs;
+        auto anm_jacked_rhs = character->animations->car_jacked_lhs;
         auto anm_current = character->animator->getAnimation(AnimIndexAction);
 
         if (anm_current == anm_jacked_lhs || anm_current == anm_jacked_rhs) {
@@ -339,10 +339,10 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     auto exitPos = vehicle->getSeatEntryPositionWorld(seat);
     auto exitPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_exit = character->animations.car_getout_lhs;
+    auto anm_exit = character->animations->car_getout_lhs;
 
     if (exitPosLocal.x > 0.f) {
-        anm_exit = character->animations.car_getout_rhs;
+        anm_exit = character->animations->car_getout_rhs;
     }
 
     if (vehicle->getVehicle()->vehicletype_ == VehicleModelInfo::BOAT) {

--- a/rwengine/src/data/AnimGroup.cpp
+++ b/rwengine/src/data/AnimGroup.cpp
@@ -1,0 +1,39 @@
+#include "AnimGroup.hpp"
+
+AnimGroup::AnimGroup(AnimationSet &animations, const std::string &name)
+    : idle(find(animations, name, "idle_stance"))
+    , walk(find(animations, name, "walk_player"))
+    , walk_start(find(animations, name, "walk_start"))
+    , run(find(animations, name, "run_player"))
+    , sprint(find(animations, name, "sprint_civi"))
+    , walk_right(find(animations, name, "walk_player_right"))
+    , walk_right_start(find(animations, name, "walk_start_right"))
+    , walk_left(find(animations, name, "walk_player_left"))
+    , walk_left_start(find(animations, name, "walk_start_left"))
+    , walk_back(find(animations, name, "walk_player_back"))
+    , walk_back_start(find(animations, name, "walk_start_back"))
+    , jump_start(find(animations, name, "jump_launch"))
+    , jump_glide(find(animations, name, "jump_glide"))
+    , jump_land(find(animations, name, "jump_land"))
+    , car_sit(find(animations, name, "car_sit"))
+    , car_sit_low(find(animations, name, "car_lsit"))
+    , car_open_lhs(find(animations, name, "car_open_lhs"))
+    , car_getin_lhs(find(animations, name, "car_getin_lhs"))
+    , car_getout_lhs(find(animations, name, "car_getout_lhs"))
+    , car_pullout_lhs(find(animations, name, "car_pullout_lhs"))
+    , car_jacked_lhs(find(animations, name, "car_jackedlhs"))
+    , car_open_rhs(find(animations, name, "car_open_rhs"))
+    , car_getin_rhs(find(animations, name, "car_getin_rhs"))
+    , car_getout_rhs(find(animations, name, "car_getout_rhs"))
+    , car_pullout_rhs(find(animations, name, "car_pullout_rhs"))
+    , car_jacked_rhs(find(animations, name, "car_jackedrhs"))
+    , kd_front(find(animations, name, "kd_front"))
+    , ko_shot_front(find(animations, name, "ko_shot_front")) {
+}
+
+Animation *AnimGroup::find(AnimationSet &animations, const std::string &group,
+                           const std::string &anim) {
+    // @todo actually find the correct animation
+    RW_UNUSED(group);
+    return animations[anim];
+}

--- a/rwengine/src/data/AnimGroup.hpp
+++ b/rwengine/src/data/AnimGroup.hpp
@@ -1,0 +1,55 @@
+#ifndef RWENGINE_DATA_ANIMGROUP_HPP
+#define RWENGINE_DATA_ANIMGROUP_HPP
+#include <memory>
+#include <unordered_map>
+#include "rw/types.hpp"
+
+struct Animation;
+
+struct AnimGroup {
+    /* Animations */
+    Animation* idle;
+    Animation* walk;
+    Animation* walk_start;
+    Animation* run;
+    Animation* sprint;
+
+    Animation* walk_right;
+    Animation* walk_right_start;
+    Animation* walk_left;
+    Animation* walk_left_start;
+
+    Animation* walk_back;
+    Animation* walk_back_start;
+
+    Animation* jump_start;
+    Animation* jump_glide;
+    Animation* jump_land;
+
+    Animation* car_sit;
+    Animation* car_sit_low;
+
+    Animation* car_open_lhs;
+    Animation* car_getin_lhs;
+    Animation* car_getout_lhs;
+    Animation* car_pullout_lhs;
+    Animation* car_jacked_lhs;
+
+    Animation* car_open_rhs;
+    Animation* car_getin_rhs;
+    Animation* car_getout_rhs;
+    Animation* car_pullout_rhs;
+    Animation* car_jacked_rhs;
+
+    Animation* kd_front;
+    Animation* ko_shot_front;
+
+    AnimGroup(AnimationSet& animations, const std::string&);
+
+    static Animation* find(AnimationSet&, const std::string& group,
+                           const std::string& anim);
+};
+
+using AnimGroups = std::unordered_map<std::string, std::unique_ptr<AnimGroup>>;
+
+#endif

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -58,6 +58,9 @@ void GameData::load() {
 
     loadIFP("ped.ifp");
 
+    /// @todo load real data
+    pedAnimGroups["player"] = std::make_unique<AnimGroup>(animations, "player");
+
     // Clear existing zones
     gamezones = ZoneDataList{
         {"CITYZON", 0, {-4000.f, -4000.f, -500.f}, {4000.f, 4000.f, 500.f}, 0}};

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -7,6 +7,7 @@ class Logger;
 #include <data/GameTexts.hpp>
 #include <data/PedData.hpp>
 #include <data/ZoneData.hpp>
+#include <data/AnimGroup.hpp>
 #include <loaders/LoaderDFF.hpp>
 #include <loaders/LoaderIDE.hpp>
 #include <loaders/LoaderIFP.hpp>
@@ -280,6 +281,11 @@ public:
      * Loaded Animations
      */
     AnimationSet animations;
+
+    /**
+     * Pedestrian Animation Groups
+     */
+    AnimGroups pedAnimGroups;
 
     /**
      * DynamicObjectData

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <glm/glm.hpp>
 #include <objects/GameObject.hpp>
+#include <data/AnimGroup.hpp>
 
 constexpr int kMaxInventorySlots = 13;
 
@@ -35,64 +36,6 @@ struct CharacterState {
 
 class VehicleObject;
 class GameWorld;
-
-struct AnimationGroup {
-    Animation* idle;
-    Animation* walk;
-    Animation* walk_start;
-    Animation* run;
-    Animation* sprint;
-
-    Animation* walk_right;
-    Animation* walk_right_start;
-    Animation* walk_left;
-    Animation* walk_left_start;
-
-    Animation* walk_back;
-    Animation* walk_back_start;
-
-    Animation* jump_start;
-    Animation* jump_glide;
-    Animation* jump_land;
-
-    Animation* car_sit;
-    Animation* car_sit_low;
-
-    Animation* car_open_lhs;
-    Animation* car_getin_lhs;
-    Animation* car_getout_lhs;
-    Animation* car_jacked_lhs;
-    Animation* car_pullout_lhs;
-
-    Animation* car_open_rhs;
-    Animation* car_getin_rhs;
-    Animation* car_getout_rhs;
-    Animation* car_jacked_rhs;
-    Animation* car_pullout_rhs;
-
-    Animation* kd_front;
-    Animation* ko_shot_front;
-
-    AnimationGroup()
-        : idle(nullptr)
-        , walk(nullptr)
-        , walk_start(nullptr)
-        , run(nullptr)
-        , jump_start(nullptr)
-        , jump_glide(nullptr)
-        , jump_land(nullptr)
-        , car_sit(nullptr)
-        , car_sit_low(nullptr)
-        , car_open_lhs(nullptr)
-        , car_getin_lhs(nullptr)
-        , car_getout_lhs(nullptr)
-        , car_open_rhs(nullptr)
-        , car_getin_rhs(nullptr)
-        , car_getout_rhs(nullptr)
-        , kd_front(nullptr)
-        , ko_shot_front(nullptr) {
-    }
-};
 
 /**
  * @brief The CharacterObject struct
@@ -128,7 +71,7 @@ public:
 
     CharacterController* controller;
 
-    AnimationGroup animations;
+    AnimGroup* animations;
 
     /**
      * @param pos

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_death) {
         character->tick(0.16f);
 
         BOOST_CHECK_EQUAL(character->animator->getAnimation(0),
-                          character->animations.ko_shot_front);
+                          character->animations->ko_shot_front);
 
         Global::get().e->destroyObject(character);
         delete controller;


### PR DESCRIPTION
- Refactor Animation Groups
- Add hard-coded data for each animation group
- Refactor CharacterController to remove usage of Animation* (mostly, still talks directly to Animator in a few places)
- Apply the correct animation group to every character

Remaining Tasks:
- [ ] Consider better ways of expressing the hard-coded animation groups, either in code or via a data file (probably code for now)
- [x] Tidy up the "get my animation group" code
- [x] Add the missing flags

Future Stuff:
- Improve animator to make use of the extra flags
- Improve animator to remove the jank